### PR TITLE
FIX production result saving. MAINT update when to use cuda backend. ENH add option to use himalaya to approximate OLS.

### DIFF
--- a/scripts/tfsenc_config.py
+++ b/scripts/tfsenc_config.py
@@ -4,6 +4,7 @@ import argparse
 import getpass
 import subprocess
 import numpy as np
+import torch
 from himalaya.backend import set_backend
 
 ELEC_SIGNAL_PREPROCESS_MAP = {
@@ -146,9 +147,12 @@ def setup_environ(args):
     args.output_dir = os.path.join(OUTPUT_DIR, RESULT_PARENT_DIR, RESULT_CHILD_DIR)
     os.makedirs(args.output_dir, exist_ok=True)
 
-    if args.ridge:
+    if torch.cuda.is_available():
         print("set backend to cuda")
         backend = set_backend("torch_cuda", on_error="warn")
+    else:
+        print("set backend to cpu numpy")
+        backend = set_backend("numpy", on_error="warn")
 
     os.environ["PYTORCH_CUDA_ALLOC_CONF"] = "max_split_size_mb:512"  # HACK
 

--- a/scripts/tfsenc_encoding.py
+++ b/scripts/tfsenc_encoding.py
@@ -165,8 +165,10 @@ def encoding_regression(args, X, Y, folds):
         if not args.ridge:  # ols
             if args.pca_to == 0:
                 print(f"Running OLS, emb_dim = {Xtrain.shape[1]}")
-                model = make_pipeline(StandardScaler(), LinearRegression())
-                # model = make_pipeline(StandardScaler(), RidgeCV(alphas=[0]))
+                if args.himalaya:
+                    model = make_pipeline(StandardScaler(), RidgeCV(alphas=[1e-9]))
+                else:
+                    model = make_pipeline(StandardScaler(), LinearRegression())
             else:  # pca + ols
                 print(f"Running PCA (from {Xtest.shape[1]} to {args.pca_to}) + OLS")
                 model = make_pipeline(

--- a/scripts/tfsenc_main.py
+++ b/scripts/tfsenc_main.py
@@ -146,7 +146,7 @@ def single_electrode_encoding(electrode, args, datum, stitch_index):
         if len(np.unique(prod_data[2])) < args.cv_fold_num:
             print(f"{args.sid} {elec_name} failed prod groupkfold")
         else:
-            run_encoding(args, *prod_data)
+            result = run_encoding(args, *prod_data)
             write_encoding_results(args, result, f"{elec_name}_prod.csv")
 
     return (sid, elec_name, len(prod_data[0]), len(comp_data[0]))


### PR DESCRIPTION
This PR implements the following changes:
- A bugfix to properly save the production results (right now the comprehension results are also being saved as the production results).
- Adding the option to compare the current OLS implementation to himalaya with a very small alpha. The results are approximately the same between the two methods and running himalaya is faster (I think because of the GPU acceleration), though it feels weird and hacky to use a very small alpha to implement ~OLS.
- Using the himalaya torch_cuda backend if and only if there are GPUs available.

Sorry I stuffed a bunch of things into this PR, but will keep them more focused in the future.